### PR TITLE
Fix error on sequences longer than 655360 because of `Array.apply`

### DIFF
--- a/src/feature-viewer.ts
+++ b/src/feature-viewer.ts
@@ -623,9 +623,7 @@ class FeatureViewer {
         let rtickStep = Math.round(this.commons.fvLength/10); // fraction of a tenth
         let tickStep = Math.round(rtickStep/10)*10; // nearest 10th multiple
 
-        let tickArray = Array(this.commons.fvLength)
-          .fill(0)
-          .map(function (value, index, ar) { return index; })
+        let tickArray = Array.from(Array(this.commons.fvLength).keys())
           .filter(function (value, index, ar) {
             return (index % tickStep == 0 && index !== 0);
           });

--- a/src/feature-viewer.ts
+++ b/src/feature-viewer.ts
@@ -623,9 +623,12 @@ class FeatureViewer {
         let rtickStep = Math.round(this.commons.fvLength/10); // fraction of a tenth
         let tickStep = Math.round(rtickStep/10)*10; // nearest 10th multiple
 
-        let tickArray = Array.apply(null, {length: this.commons.fvLength}).map(Number.call, Number).filter(function (value, index, ar) {
+        let tickArray = Array(this.commons.fvLength)
+          .fill(0)
+          .map(function (value, index, ar) { return index; })
+          .filter(function (value, index, ar) {
             return (index % tickStep == 0 && index !== 0);
-        } );
+          });
 
         //Create Axis
         this.commons.xAxis = d3.axisBottom(this.commons.scaling)


### PR DESCRIPTION
Hi again @Lisanna ,

this one is a fix for a bug I noticed when trying to visualize large contigs: with any sequence larger than 655360 letters the `Array.apply` call would raise a `RangeError` (I found an explanation [here](https://stackoverflow.com/a/52949093)). 

I used a different way to construct the `tickArray` without using `Array.apply` but kept the same filter. I'm not that experienced in JavaScript but from what I read it's still a fairly efficient approach. Applying this patch let me visualize very large sequences without trouble.